### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/rebestAzDevOpsLearn/1f4631c2-b72f-4c78-b1ad-dcacd31bb45d/59460427-cbe8-4cbe-b64c-d128f15645ef/_apis/work/boardbadge/ad72de88-8fc0-4b7b-b2e5-8b24342a24b0)](https://dev.azure.com/rebestAzDevOpsLearn/1f4631c2-b72f-4c78-b1ad-dcacd31bb45d/_boards/board/t/59460427-cbe8-4cbe-b64c-d128f15645ef/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/rebestAzDevOpsLearn/1f4631c2-b72f-4c78-b1ad-dcacd31bb45d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.